### PR TITLE
Add support for horizontal_rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This is suitable for the new format of BoxNotes after August 2022 (see [this iss
     - highlight
  - Image (local)
  - Hyperlink
+ - Divider Line (Horizontal Rule)
 
 ## Not supported yet
  - Formatting
@@ -40,6 +41,5 @@ This is suitable for the new format of BoxNotes after August 2022 (see [this iss
  - File preview
  - Code Block
  - Block Quote
- - Divier Line
  - Table of Contents (?)
  - Callout

--- a/boxnote-converter/html_parser.py
+++ b/boxnote-converter/html_parser.py
@@ -69,6 +69,9 @@ def parse_content(content: Union[Dict, List], contents: List[str], ignore_paragr
     elif type_tag == 'paragraph' and ignore_paragraph:
         logger.info('paragraph ignore')
         parse_content(content.get('content', []), contents)
+    elif type_tag == 'horizontal_rule':
+        logger.info('horizontal_rule')
+        contents.append(html_mapper.get_tag_open('horizontal_rule'))
     elif type_tag == 'text':
         logger.info('text')
         contents.append(html_mapper.get_tag_open('text'))

--- a/boxnote-converter/mapper/html_mapper.py
+++ b/boxnote-converter/mapper/html_mapper.py
@@ -44,6 +44,7 @@ tag_open_map = {
     'check_list': '<ul style="list-style-type:none">',
     'check_list_item': '<li><input type="checkbox">',
     'check_list_item_checked': '<li><input type="checkbox" checked>',
+    'horizontal_rule': '<hr/>',
     'table': '<table>',
     'table_row': '<tr>',
     'table_cell': '<td colspan={colspan} rowspan={rowspan} colwidth={colwidth}>',


### PR DESCRIPTION
This PR adds support for `horizontal_rule` as the `<hr/>` HTML tag.