### PR TITLE
Add blockquote support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This is suitable for the new format of BoxNotes after August 2022 (see [this iss
     - highlight
  - Image (local)
  - Hyperlink
+ - Block Quote
 
 ## Not supported yet
  - Formatting
@@ -39,7 +40,6 @@ This is suitable for the new format of BoxNotes after August 2022 (see [this iss
  - Image (Box shared link)
  - File preview
  - Code Block
- - Block Quote
  - Divier Line
  - Table of Contents (?)
  - Callout

--- a/boxnote-converter/html_parser.py
+++ b/boxnote-converter/html_parser.py
@@ -69,6 +69,11 @@ def parse_content(content: Union[Dict, List], contents: List[str], ignore_paragr
     elif type_tag == 'paragraph' and ignore_paragraph:
         logger.info('paragraph ignore')
         parse_content(content.get('content', []), contents)
+    elif type_tag == 'blockquote':
+        logger.info('blockquote')
+        contents.append(html_mapper.get_tag_open('blockquote'))
+        parse_content(content.get('content', []), contents)
+        contents.append(html_mapper.get_tag_close('blockquote'))
     elif type_tag == 'text':
         logger.info('text')
         contents.append(html_mapper.get_tag_open('text'))

--- a/boxnote-converter/mapper/html_mapper.py
+++ b/boxnote-converter/mapper/html_mapper.py
@@ -27,6 +27,15 @@ table tr:nth-child(even) {
 table tr :hover {
     background-color: #66ccff;
 }
+blockquote {
+    display: block;
+    border-left: 6px solid #d3d3d3;
+    padding-left: 16px;
+    margin-block-start: 1em;
+    margin-block-end: 1em;
+    margin-inline-start: 40px;
+    margin-inline-end: 40px;
+}
 </style>
 '''
 
@@ -39,6 +48,7 @@ tag_open_map = {
     'underline': '<u>',
     'strikethrough': '<s>',
     'ordered_list': '<ol>',
+    'blockquote': '<blockquote>',
     'bullet_list': '<ul>',
     'list_item': '<li>',
     'check_list': '<ul style="list-style-type:none">',
@@ -64,6 +74,7 @@ tag_close_map = {
     'underline': '</u>',
     'strikethrough': '</s>',
     'ordered_list': '</ol>',
+    'blockquote': '</blockquote>',
     'bullet_list': '</ul>',
     'list_item': '</li>',
     'check_list': '</ul>',


### PR DESCRIPTION
This PR adds support for `blockquote` as the `<blockquote>` HTML tag with basic formatting.