### PR TITLE
Add default argument to html.parse

### DIFF
--- a/boxnote-converter/html_parser.py
+++ b/boxnote-converter/html_parser.py
@@ -20,8 +20,8 @@ user = None
 
 def parse(
         boxnote_content: Union[str, bytes, bytearray],
-        title: str,
-        workdir: Path,
+        title: str = None,
+        workdir: Path = None,
         access_token: str = None,
         user_id: str = None) -> str:
     """


### PR DESCRIPTION
First thanks a lot for this tool. Really useful.

I use the function (and not the CLI). I use `parse` but pass direcly the bytes. In this case we don't need a title and workdir. 
